### PR TITLE
Use libsodiums hex conversion instead of PHPs native one

### DIFF
--- a/source/Threema/Console/Command/Base.php
+++ b/source/Threema/Console/Command/Base.php
@@ -135,7 +135,7 @@ abstract class Base {
 	public function getArgumentPrivateKey($pos) {
 		$content = Common::getPrivateKey($this->getArgumentStringOrFileContent($pos));
 		if(null !== $content) {
-			return hex2bin($content);
+			return \Sodium\hex2bin($content);
 		}
 		return null;
 	}
@@ -147,7 +147,7 @@ abstract class Base {
 	public function getArgumentPublicKey($pos) {
 		$content = Common::getPublicKey($this->getArgumentStringOrFileContent($pos));
 		if(null !== $content) {
-			return hex2bin($content);
+			return \Sodium\hex2bin($content);
 		}
 		return null;
 	}

--- a/source/Threema/Console/Command/Decrypt.php
+++ b/source/Threema/Console/Command/Decrypt.php
@@ -20,8 +20,8 @@ class Decrypt extends Base {
 	function doRun() {
 		$privateKey = $this->getArgumentPrivateKey(self::argPrivateKey);
 		$publicKey = $this->getArgumentPublicKey(self::argPublicKey);
-		$nonce = hex2bin($this->getArgument(self::argNonce));
-		$input = hex2bin($this->readStdIn());
+		$nonce = \Sodium\hex2bin($this->getArgument(self::argNonce));
+		$input = \Sodium\hex2bin($this->readStdIn());
 
 		Common::required($privateKey, $publicKey, $nonce, $input);
 		$cryptTool = CryptTool::getInstance();

--- a/source/Threema/Console/Command/DerivePublicKey.php
+++ b/source/Threema/Console/Command/DerivePublicKey.php
@@ -25,6 +25,6 @@ class DerivePublicKey extends Base {
 		$cryptTool = CryptTool::getInstance();
 
 		$publicKey = $cryptTool->derivePublicKey($privateKey);
-		Common::l(Common::convertPublicKey(bin2hex($publicKey)));
+		Common::l(Common::convertPublicKey(\Sodium\bin2hex($publicKey)));
 	}
 }

--- a/source/Threema/Console/Command/Encrypt.php
+++ b/source/Threema/Console/Command/Encrypt.php
@@ -35,8 +35,8 @@ class Encrypt extends Base {
 		$newNonce = $cryptTool->randomNonce();
 		$encryptedMessageText = $cryptTool->encryptMessageText($textToEncrypt, $privateKey, $publicKey, $newNonce);
 
-		Common::ln(bin2hex($newNonce));
+		Common::ln(\Sodium\bin2hex($newNonce));
 		//output encrypted text
-		Common::ln(bin2hex($encryptedMessageText));
+		Common::ln(\Sodium\bin2hex($encryptedMessageText));
 	}
 }

--- a/source/Threema/Console/Command/GenerateKeyPair.php
+++ b/source/Threema/Console/Command/GenerateKeyPair.php
@@ -20,8 +20,8 @@ class GenerateKeyPair extends Base {
 	function doRun() {
 		$keyPair = CryptTool::getInstance()->generateKeyPair();
 
-		$privateKeyHex = bin2hex($keyPair->privateKey);
-		$publicKeyHex = bin2hex($keyPair->publicKey);
+		$privateKeyHex = \Sodium\bin2hex($keyPair->privateKey);
+		$publicKeyHex = \Sodium\bin2hex($keyPair->publicKey);
 
 		file_put_contents($this->getArgument(self::argPrivateKeyFile), Common::convertPrivateKey($privateKeyHex)."\n");
 		file_put_contents($this->getArgument(self::argPublicKeyFile), Common::convertPublicKey($publicKeyHex)."\n");

--- a/source/Threema/Console/Command/ReceiveMessage.php
+++ b/source/Threema/Console/Command/ReceiveMessage.php
@@ -38,11 +38,11 @@ class ReceiveMessage extends Base {
 		$id = $this->getArgumentThreemaId(self::argFrom);
 		$secret = $this->getArgument(self::argSecret);
 		$privateKey = $this->getArgumentPrivateKey(self::argPrivateKey);
-		$nonce = hex2bin($this->getArgument(self::argNonce));
+		$nonce = \Sodium\hex2bin($this->getArgument(self::argNonce));
 		$messageId = $this->getArgument(self::argMessageId);
 		$outputFolder = $this->getArgument(self::argOutputFolder);
 
-		$box = hex2bin($this->readStdIn());
+		$box = \Sodium\hex2bin($this->readStdIn());
 
 		Common::required($box, $id, $secret, $privateKey, $nonce);
 

--- a/source/Threema/MsgApi/Commands/SendE2E.php
+++ b/source/Threema/MsgApi/Commands/SendE2E.php
@@ -55,8 +55,8 @@ class SendE2E implements CommandInterface {
 	 */
 	function getParams() {
 		$p['to'] = $this->threemaId;
-		$p['nonce'] = bin2hex($this->getNonce());
-		$p['box'] = bin2hex($this->getBox());
+		$p['nonce'] = \Sodium\bin2hex($this->getNonce());
+		$p['box'] = \Sodium\bin2hex($this->getBox());
 		return $p;
 	}
 

--- a/source/Threema/MsgApi/Helpers/E2EHelper.php
+++ b/source/Threema/MsgApi/Helpers/E2EHelper.php
@@ -216,7 +216,7 @@ class E2EHelper {
 		$message = $this->cryptTool->decryptMessage(
 			$box,
 			$this->privateKey,
-			hex2bin($receiverPublicKey->getPublicKey()),
+			\Sodium\hex2bin($receiverPublicKey->getPublicKey()),
 			$nonce
 		);
 
@@ -231,7 +231,7 @@ class E2EHelper {
 			if(null !== $result && true === $result->isSuccess()) {
 				$image = $this->cryptTool->decryptImage(
 					$result->getData(),
-					hex2bin($receiverPublicKey->getPublicKey()),
+					\Sodium\hex2bin($receiverPublicKey->getPublicKey()),
 					$this->privateKey,
 					$message->getNonce()
 				);
@@ -254,7 +254,7 @@ class E2EHelper {
 			if(null !== $result && true === $result->isSuccess()) {
 				$file = $this->cryptTool->decryptFile(
 					$result->getData(),
-					hex2bin($message->getEncryptionKey()));
+					\Sodium\hex2bin($message->getEncryptionKey()));
 
 				if (null === $file) {
 					throw new Exception('file decryption failed');
@@ -272,7 +272,7 @@ class E2EHelper {
 				if(null !== $result && true === $result->isSuccess()) {
 					$file = $this->cryptTool->decryptFileThumbnail(
 						$result->getData(),
-						hex2bin($message->getEncryptionKey()));
+						\Sodium\hex2bin($message->getEncryptionKey()));
 
 					if(null === $file) {
 						throw new Exception('thumbnail decryption failed');
@@ -313,7 +313,7 @@ class E2EHelper {
 			}
 		}
 
-		return hex2bin($receiverPublicKey->getPublicKey());
+		return \Sodium\hex2bin($receiverPublicKey->getPublicKey());
 	}
 
 	/**

--- a/source/Threema/MsgApi/Messages/DeliveryReceipt.php
+++ b/source/Threema/MsgApi/Messages/DeliveryReceipt.php
@@ -80,7 +80,7 @@ class DeliveryReceipt extends ThreemaMessage {
 		$str = "Delivery receipt (" . $this->getReceiptTypeName() . "): ";
 		$hexMessageIds = array();
 		foreach ($this->ackedMessageIds as $messageId) {
-			$hexMessageIds[] = bin2hex($messageId);
+			$hexMessageIds[] = \Sodium\bin2hex($messageId);
 		}
 		$str .= join(", ", $hexMessageIds);
 		return $str;

--- a/source/Threema/MsgApi/Tests/CryptToolTest.php
+++ b/source/Threema/MsgApi/Tests/CryptToolTest.php
@@ -49,10 +49,10 @@ class CryptToolTests extends \PHPUnit_Framework_TestCase {
 			$publicKey = Common::getPublicKey(Constants::myPublicKey);
 			$this->assertNotNull($publicKey);
 
-			$message = $cryptTool->decryptMessage(hex2bin($box),
-				hex2bin($privateKey),
-				hex2bin($publicKey),
-				hex2bin($nonce));
+			$message = $cryptTool->decryptMessage(\Sodium\hex2bin($box),
+				\Sodium\hex2bin($privateKey),
+				\Sodium\hex2bin($publicKey),
+				\Sodium\hex2bin($nonce));
 
 			$this->assertNotNull($message);
 			$this->assertTrue($message instanceof TextMessage);
@@ -75,16 +75,16 @@ class CryptToolTests extends \PHPUnit_Framework_TestCase {
 			$this->assertNotNull($publicKey);
 
 			$message = $cryptTool->encryptMessageText($text,
-				hex2bin($privateKey),
-				hex2bin($publicKey),
-				hex2bin($nonce));
+				\Sodium\hex2bin($privateKey),
+				\Sodium\hex2bin($publicKey),
+				\Sodium\hex2bin($nonce));
 
 			$this->assertNotNull($message);
 
 			$box = $cryptTool->decryptMessage($message,
-				hex2bin(Common::getPrivateKey(Constants::otherPrivateKey)),
-				hex2bin(Common::getPublicKey(Constants::myPublicKey)),
-				hex2bin($nonce));
+				\Sodium\hex2bin(Common::getPrivateKey(Constants::otherPrivateKey)),
+				\Sodium\hex2bin(Common::getPublicKey(Constants::myPublicKey)),
+				\Sodium\hex2bin($nonce));
 
 			$this->assertNotNull($box);
 		});
@@ -93,8 +93,8 @@ class CryptToolTests extends \PHPUnit_Framework_TestCase {
 
 	public function testDerivePublicKey() {
 		$this->doTest(function(CryptTool $cryptTool, $prefix){
-			$publicKey = $cryptTool->derivePublicKey(hex2bin(Common::getPrivateKey(Constants::myPrivateKey)));
-			$myPublicKey = hex2bin(Common::getPublicKey(Constants::myPublicKey));
+			$publicKey = $cryptTool->derivePublicKey(\Sodium\hex2bin(Common::getPrivateKey(Constants::myPrivateKey)));
+			$myPublicKey = \Sodium\hex2bin(Common::getPublicKey(Constants::myPublicKey));
 
 			$this->assertEquals($publicKey, $myPublicKey, $prefix.' derive public key failed');
 		});
@@ -105,11 +105,11 @@ class CryptToolTests extends \PHPUnit_Framework_TestCase {
 
 		/** @noinspection PhpUnusedParameterInspection */
 		$this->doTest(function(CryptTool $cryptTool, $prefix) use($threemaIconContent) {
-			$privateKey = hex2bin(Common::getPrivateKey(Constants::myPrivateKey));
-			$publicKey = hex2bin(Common::getPublicKey(Constants::myPublicKey));
+			$privateKey = \Sodium\hex2bin(Common::getPrivateKey(Constants::myPrivateKey));
+			$publicKey = \Sodium\hex2bin(Common::getPublicKey(Constants::myPublicKey));
 
-			$otherPrivateKey = hex2bin(Common::getPrivateKey(Constants::otherPrivateKey));
-			$otherPublicKey = hex2bin(Common::getPublicKey(Constants::otherPublicKey));
+			$otherPrivateKey = \Sodium\hex2bin(Common::getPrivateKey(Constants::otherPrivateKey));
+			$otherPublicKey = \Sodium\hex2bin(Common::getPublicKey(Constants::otherPublicKey));
 
 			$result = $cryptTool->encryptImage($threemaIconContent, $privateKey, $otherPublicKey);
 

--- a/source/Threema/MsgApi/Tools/CryptTool.php
+++ b/source/Threema/MsgApi/Tools/CryptTool.php
@@ -129,7 +129,7 @@ abstract class CryptTool {
 			$senderPrivateKey,
 			$recipientPublicKey,
 			$nonce) {
-		$message = "\x02" . hex2bin($uploadFileResult->getBlobId());
+		$message = "\x02" . \Sodium\hex2bin($uploadFileResult->getBlobId());
 		$message .= pack('V', $encryptResult->getSize());
 		$message .= $encryptResult->getNonce();
 
@@ -153,7 +153,7 @@ abstract class CryptTool {
 
 		$messageContent = array(
 			'b' => $uploadFileResult->getBlobId(),
-			'k' => bin2hex($encryptResult->getKey()),
+			'k' => \Sodium\bin2hex($encryptResult->getKey()),
 			'm' => $fileAnalysisResult->getMimeType(),
 			'n' => $fileAnalysisResult->getFileName(),
 			's' => $fileAnalysisResult->getSize(),
@@ -280,7 +280,7 @@ abstract class CryptTool {
 				$blobId = $piece->__invoke(self::BLOB_ID_LEN);
 				$length = $piece->__invoke(self::IMAGE_FILE_SIZE_LEN);
 				$nonce = $piece->__invoke(self::IMAGE_NONCE_LEN);
-				return new ImageMessage(bin2hex($blobId), bin2hex($length), $nonce);
+				return new ImageMessage(\Sodium\bin2hex($blobId), \Sodium\bin2hex($length), $nonce);
 			case FileMessage::TYPE_CODE:
 				/* Image Message */
 				$decodeResult = json_decode(substr($data, 1), true);


### PR DESCRIPTION
This fixes potential timing attacks and it also fixes https://github.com/rugk/threema-msgapi-sdk-php/issues/32

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/rugk/threema-msgapi-sdk-php/33)

<!-- Reviewable:end -->
