### PR TITLE
Fix bug in PHP keystore

### DIFF
--- a/source/Threema/MsgApi/PublicKeyStores/PhpFile.php
+++ b/source/Threema/MsgApi/PublicKeyStores/PhpFile.php
@@ -71,7 +71,7 @@ class PhpFile extends PublicKeyStore
 		//Parse file
 		$keystore = array();
 		$isMsgApiKeystore = true;
-		require_once $this->file;
+		require $this->file;
 
 		//Update cache
 		$this->keystore = $keystore;


### PR DESCRIPTION
The require_once may have caused problems if you created multiple
instances of the PHP keystore.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/rugk/threema-msgapi-sdk-php/36)

<!-- Reviewable:end -->
