### PR TITLE
Add fallback curl constant definions

### DIFF
--- a/source/bootstrap.php
+++ b/source/bootstrap.php
@@ -2,11 +2,10 @@
 require_once("Salt/autoload.php");
 
 //define possibly missing constants
-//thanks https://stackoverflow.com/questions/31266501/use-of-undefined-constant-curl-sslversion-tlsv1-assumed-curl-sslversion-tlsv1/31267155#answer-32018088
-defined('CURL_SSLVERSION_DEFAULT') || define('CURL_SSLVERSION_DEFAULT', 0);
-defined('CURL_SSLVERSION_TLSv1')   || define('CURL_SSLVERSION_TLSv1', 1);
-defined('CURL_SSLVERSION_SSLv2')   || define('CURL_SSLVERSION_SSLv2', 2);
-defined('CURL_SSLVERSION_SSLv3')   || define('CURL_SSLVERSION_SSLv3', 3);
+defined('CURL_SSLVERSION_DEFAULT')  || define('CURL_SSLVERSION_DEFAULT', 0);
+defined('CURL_SSLVERSION_TLSv1')    || define('CURL_SSLVERSION_TLSv1', 1);
+defined('CURL_SSLVERSION_TLSv1_1') || define('CURL_SSLVERSION_TLSv1_1', 5);
+defined('CURL_SSLVERSION_TLSv1_2')  || define('CURL_SSLVERSION_TLSv1_2', 6);
 
 //define autoloader
 $d = dirname(__FILE__);

--- a/source/bootstrap.php
+++ b/source/bootstrap.php
@@ -4,7 +4,7 @@ require_once("Salt/autoload.php");
 //define possibly missing constants
 defined('CURL_SSLVERSION_DEFAULT')  || define('CURL_SSLVERSION_DEFAULT', 0);
 defined('CURL_SSLVERSION_TLSv1')    || define('CURL_SSLVERSION_TLSv1', 1);
-defined('CURL_SSLVERSION_TLSv1_1') || define('CURL_SSLVERSION_TLSv1_1', 5);
+defined('CURL_SSLVERSION_TLSv1_1')  || define('CURL_SSLVERSION_TLSv1_1', 5);
 defined('CURL_SSLVERSION_TLSv1_2')  || define('CURL_SSLVERSION_TLSv1_2', 6);
 
 //define autoloader

--- a/source/bootstrap.php
+++ b/source/bootstrap.php
@@ -1,7 +1,14 @@
 <?php
 require_once("Salt/autoload.php");
 
-//Define autoloader
+//define possibly missing constants
+//thanks https://stackoverflow.com/questions/31266501/use-of-undefined-constant-curl-sslversion-tlsv1-assumed-curl-sslversion-tlsv1/31267155#answer-32018088
+defined('CURL_SSLVERSION_DEFAULT') || define('CURL_SSLVERSION_DEFAULT', 0);
+defined('CURL_SSLVERSION_TLSv1')   || define('CURL_SSLVERSION_TLSv1', 1);
+defined('CURL_SSLVERSION_SSLv2')   || define('CURL_SSLVERSION_SSLv2', 2);
+defined('CURL_SSLVERSION_SSLv3')   || define('CURL_SSLVERSION_SSLv3', 3);
+
+//define autoloader
 $d = dirname(__FILE__);
 spl_autoload_register(function($className) use($d)
 {


### PR DESCRIPTION
This fixes "undefined constant" errors when PHP <5.5 is used.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/rugk/threema-msgapi-sdk-php/37)

<!-- Reviewable:end -->
